### PR TITLE
Fix shaking animation by adding min-height to hero title (fixes #21)

### DIFF
--- a/Homepage CSS/hero.css
+++ b/Homepage CSS/hero.css
@@ -45,6 +45,7 @@
   line-height: 1.3;
   color: var(--text);
   text-shadow: 0 0 12px rgba(255, 215, 0, 0.2);
+  min-height: 65px;
 }
 
 [data-theme="light"] .hero-title {


### PR DESCRIPTION
### Fix Description
This PR fixes the shaking/layout shift issue caused by the typewriter animation (Issue #21).

### Solution
I added a `min-height: 65px` to the `.hero-title` class in `hero.css`. This prevents the layout from collapsing when the text is being deleted/retyped, ensuring a stable layout.