### PR TITLE
Add scrollable prompt textarea with 250px height limit (#32)

### DIFF
--- a/Homepage CSS/prompt.css
+++ b/Homepage CSS/prompt.css
@@ -70,7 +70,8 @@
   color: var(--text);
   font-size: 1rem;
   resize: none;
-  overflow-y: hidden;
+  overflow-y: auto;
+  max-height: 250px;
   min-height: 50px;
   line-height: 1.5;
 }

--- a/Homepage JS/prompt.js
+++ b/Homepage JS/prompt.js
@@ -254,7 +254,7 @@ document.addEventListener("DOMContentLoaded", () => {
     if (charCount) charCount.innerText = `${promptInput.value.length} chars`;
     if (wordCount) wordCount.innerText = `${promptInput.value.trim().split(/\s+/).filter(Boolean).length} words`;
     promptInput.style.height = "auto";
-    promptInput.style.height = promptInput.scrollHeight + "px";
+    promptInput.style.height = Math.min(promptInput.scrollHeight, 250) + "px";
     generateBtn.innerText = "⚡ Generate";
   });
 
@@ -263,7 +263,7 @@ document.addEventListener("DOMContentLoaded", () => {
 ============================= */
 function autoResize() {
   promptInput.style.height = "auto";
-  promptInput.style.height = promptInput.scrollHeight + "px";
+  promptInput.style.height = Math.min(promptInput.scrollHeight, 250) + "px";
 }
 
 // Normal desktop + android fix


### PR DESCRIPTION
This PR adds a scrollable textarea to fix the issue where the prompt box kept growing and pushing the whole page down when typing long content.

 What I changed
- Added a max height of 250px to the prompt textarea.
- Enabled vertical scrolling inside the textarea.
- Added auto-resize logic so it expands normally until the limit, and then scrolls.
- Left the rest of the UI exactly as it is.

Before

(Textarea keeps expanding and pushes the whole page down)

<img width="1919" height="1057" alt="Screenshot 2025-11-19 201555" src="https://github.com/user-attachments/assets/97492479-ff77-49d2-8c2a-d5ae930c62e3" />

After

(Textarea expands up to 250px and then scrolls inside)

<img width="1919" height="1069" alt="Screenshot 2025-11-19 203600" src="https://github.com/user-attachments/assets/e5def60a-465f-4f70-8e6d-540089d76fc0" />
Why this helps
Long prompts are now easier to read and edit, and the page layout stays clean.  
No more huge textarea taking up the whole screen.

Screenshots have been added to show the before/after behavior.

Fixes #32.
