### PR TITLE
Fixed testimonial slider centering drift on all screen sizes (centering issue)

### DIFF
--- a/Homepage JS/testinomial.js
+++ b/Homepage JS/testinomial.js
@@ -111,30 +111,32 @@ let autoTimer = null;
 
 // Calculate translateX so that the current card stays perfectly centered
 function getTranslateXForIndex(index) {
-    const card = cards[index];
-    if (!card) return 0;
+  const card = cards[index];
+  if (!card) return 0;
 
-    const containerWidth = sliderContainer.getBoundingClientRect().width;
-    const cardWidth = card.getBoundingClientRect().width;
+  // Width of visible area
+  const containerWidth = sliderContainer.clientWidth;
 
-    // Card position relative to slider
-    const cardLeft = card.offsetLeft;
+  // Use layout width 
+  const cardWidth = card.offsetWidth;
 
-    // FIX: adjust for gap so card doesn't shift right
-    const sliderStyles = window.getComputedStyle(slider);
-    const gap = parseFloat(sliderStyles.gap || 0);
+  // Position from left inside the slider 
+  const cardLeft = card.offsetLeft;
 
-    // Perfect center formula (with gap correction)
-    const target = cardLeft - (containerWidth / 2) + (cardWidth / 2) - (gap / 2);
+  // Center of the card in slider coords
+  const cardCenter = cardLeft + cardWidth / 2;
 
-    return -target;
+  // cardCenter to align with the center of the container
+  const containerCenter = containerWidth / 2;
+
+  const translateX = containerCenter - cardCenter;
+
+  return translateX;
 }
+
 
 // Update card states and positions
 function updateSlider() {
-  const translateX = getTranslateXForIndex(currentIndex);
-  slider.style.transform = `translateX(${translateX}px)`;
-
   cards.forEach((card, i) => {
     card.classList.remove("active", "side");
     if (i === currentIndex) {
@@ -143,7 +145,11 @@ function updateSlider() {
       card.classList.add("side");
     }
   });
+
+  const translateX = getTranslateXForIndex(currentIndex);
+  slider.style.transform = `translateX(${translateX}px)`;
 }
+
 
 // Auto movement with smooth forward + backward loop
 function stepAuto() {


### PR DESCRIPTION
### Summary
Fixes the testimonial slider alignment drift where the active card appeared
slightly off-center (10–30px) depending on screen size.

### Root Cause
- offsetLeft (layout) was combined with getBoundingClientRect().width (transform)
- gap correction was applied unnecessarily
- card width was measured before scaling to active state, causing mismatch

### Fix
- Rewrote getTranslateXForIndex() to use layout-only metrics (offsetWidth + offsetLeft)
- Removed gap correction and transform-dependent measurements
- Centering now aligns card midpoint to container midpoint
- Ensures perfect alignment across all breakpoints and during resize

### Result
Active testimonial card now stays visually centered on all screen sizes
(mobile → ultrawide) with no drift.
