### PR TITLE
Add labels to service cards

### DIFF
--- a/Homepage CSS/our-services.css
+++ b/Homepage CSS/our-services.css
@@ -131,6 +131,33 @@
   gap: 30px;
 }
 
+.service-badges {
+  position: absolute;
+  top: 22px;
+  right: 22px;
+  display: flex;
+  gap: 8px;
+  z-index: 3;
+}
+
+.service-badge {
+  background: var(--gold-primary);
+  color: #1a1a1a;
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 6px 10px;
+  border-radius: 999px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  box-shadow: 0 4px 12px rgba(255, 215, 0, 0.35);
+  white-space: nowrap;
+}
+
+/* Slight visual difference if needed later */
+.service-badge.available {
+  opacity: 0.95;
+}
+
 /* Service Card Styles */
 .service-card {
   position: relative;
@@ -335,5 +362,12 @@
 
   .services-glow-box:hover::after {
     right: 40%;
+  }
+}
+
+@media (max-width: 600px) {
+  .service-badges {
+    flex-direction: column;
+    align-items: flex-end;
   }
 }

--- a/index.html
+++ b/index.html
@@ -298,6 +298,10 @@
           <!-- Card 1: AI Email Generation -->
           <div class="service-card">
             <div class="card-glow"></div>
+            <div class="service-badges">
+            <span class="service-badge free">FREE</span>
+            <span class="service-badge available">AVAILABLE</span>
+            </div>
             <div class="icon-container">
               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -315,6 +319,10 @@
           <!-- Card 2: AI Email Quality Checker -->
           <div class="service-card">
             <div class="card-glow"></div>
+            <div class="service-badges">
+            <span class="service-badge free">FREE</span>
+            <span class="service-badge available">AVAILABLE</span>
+            </div>
             <div class="icon-container">
               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -330,6 +338,10 @@
           <!-- Card 3: PDF Converter & Downloader -->
           <div class="service-card">
             <div class="card-glow"></div>
+            <div class="service-badges">
+            <span class="service-badge free">FREE</span>
+            <span class="service-badge available">AVAILABLE</span>
+            </div>
             <div class="icon-container">
               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
## Description
Added two new badges — **FREE** and **AVAILABLE** — to each service card in the “Our Services” section to make it clearer to users that the services are free and currently available. The styling matches the existing Mail Karo dark/yellow theme without breaking layout on small screens.

## Related Issue
Closes #102

## Screenshot
<img width="1897" height="860" alt="Screenshot 2025-12-25 222915" src="https://github.com/user-attachments/assets/1d2eeac5-1abd-4f21-9917-5242e3300b37" />

## Acceptance Criteria
- [x] Badges visible on all service cards
- [x] Uses Mail Karo theme colors
- [x] Layout stays responsive & aligned
- [x] No text or icon overlap
- [x] Visual style looks consistent with brand
